### PR TITLE
update hello demos for dotnet-client-sdk 2.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,12 +41,12 @@ jobs:
       
       - run:
           name: build demo
-          command: dotnet build XamarinConsoleApp
+          command: dotnet build DotNetConsoleApp
       
       - run:
           name: run demo
           command: |
-            dotnet run --project XamarinConsoleApp | tee output.txt
+            dotnet run --project DotNetConsoleApp | tee output.txt
             grep "is True for this user" output.txt || (echo "Flag did not evaluate to expected true value" && exit 1)
 
   build-macos:

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/DotNetConsoleApp/DotNetConsoleApp.csproj
+++ b/DotNetConsoleApp/DotNetConsoleApp.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LaunchDarkly.XamarinSdk" Version="1.*" />
+    <PackageReference Include="LaunchDarkly.ClientSdk" Version="2.0.0-rc.1" />
   </ItemGroup>
   <Import Project="..\Shared\Shared.projitems" Label="Shared" Condition="Exists('..\Shared\Shared.projitems')" />
 </Project>

--- a/DotNetConsoleApp/Program.cs
+++ b/DotNetConsoleApp/Program.cs
@@ -1,11 +1,10 @@
 ﻿using System;
-using Common.Logging;
 using LaunchDarkly.Logging;
-using LaunchDarkly.Xamarin;
+using LaunchDarkly.Sdk.Client;
 
 namespace LaunchDarkly.Hello
 {
-    // This is the .NET Core console version of the LaunchDarkly Xamarin SDK demo. The
+    // This is the .NET Core console version of the LaunchDarkly client-side .NET SDK demo. The
     // non-platform-specific classes DemoMessages and DemoParameters are defined in ../Shared.
 
     public class Program
@@ -17,12 +16,6 @@ namespace LaunchDarkly.Hello
                 ShowMessage(DemoMessages.MobileKeyNotSet);
                 Environment.Exit(1);
             }
-
-            // Set up logging to log SDK messages to the console. ConsoleAdapter is a simple
-            // Common.Logging implementation that's provided by LaunchDarkly; Common.Logging has
-            // an equivalent class, but not on every platform.
-            LogManager.Adapter = new ConsoleAdapter(LogLevel.Info);
-            // 
 
             LdClient client = LdClient.Init(
                 DemoParameters.MobileKey,

--- a/LaunchDarkly.HelloDotNetClient.sln
+++ b/LaunchDarkly.HelloDotNetClient.sln
@@ -7,7 +7,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "XamarinIOSApp", "XamarinIOS
 EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Shared", "Shared\Shared.shproj", "{94F3C23C-0731-4A72-AB69-4FBB3D838B0F}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "XamarinConsoleApp", "XamarinConsoleApp\XamarinConsoleApp.csproj", "{41F376E1-FD4F-4BD2-9C09-57F62A679A0C}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DotNetConsoleApp", "DotNetConsoleApp\DotNetConsoleApp.csproj", "{41F376E1-FD4F-4BD2-9C09-57F62A679A0C}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 We've built a simple demo that demonstrates how LaunchDarkly's SDK works. Since the client-side .NET SDK can be used either on Xamarin-compatible mobile devices or in portable .NET code, there are three versions of the demo: a Xamarin Android app, a Xamarin iOS app, and a .NET Core console app.
 
+Important: these demos are for the _client-side_ .NET SDK, which is suitable for mobile or desktop applications. For server-side use, see https://github.com/launchdarkly/hello-dotnet-server.
+
 Below, you'll find the basic build procedures, but for more comprehensive instructions, you can visit your [Quickstart page](https://app.launchdarkly.com/quickstart#/) or the [client-side .NET SDK reference guide](https://docs.launchdarkly.com/sdk/client-side/dotnet).
 
 ## Instructions for Android and iOS

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
-# LaunchDarkly Sample Xamarin Application s
+# LaunchDarkly Sample Client-Side .NET Applications
 
-We've built a simple demo that demonstrates how LaunchDarkly's SDK works. Since the Xamarin SDK can be used either on Xamarin-compatible mobile devices or in portable .NET code, there are three versions of the demo: an Android app, an iOS app, and a .NET Core console app.
+We've built a simple demo that demonstrates how LaunchDarkly's SDK works. Since the client-side .NET SDK can be used either on Xamarin-compatible mobile devices or in portable .NET code, there are three versions of the demo: a Xamarin Android app, a Xamarin iOS app, and a .NET Core console app.
 
-Below, you'll find the basic build procedures, but for more comprehensive instructions, you can visit your [Quickstart page](https://app.launchdarkly.com/quickstart#/) or the [Xamarin SDK reference guide](https://docs.launchdarkly.com/sdk/client-side/xamarin).
+Below, you'll find the basic build procedures, but for more comprehensive instructions, you can visit your [Quickstart page](https://app.launchdarkly.com/quickstart#/) or the [client-side .NET SDK reference guide](https://docs.launchdarkly.com/sdk/client-side/dotnet).
 
 ## Instructions for Android and iOS
 
 The Android and iOS demos require Visual Studio to build and run. For iOS, besides Visual Studio you must also have [Xcode](https://developer.apple.com/xcode/). You can run either on a real device or a simulator.
 
-These demo apps use Android- and iOS-specific user interface components, rather than Xamarin Forms. The LaunchDarkly Xamarin SDK in itself has no UI functionality, so in a Xamarin Forms app there would be no difference in how you would use the SDK.
+These demo apps use Android- and iOS-specific user interface components, rather than Xamarin Forms. The LaunchDarkly SDK in itself has no UI functionality, so in a Xamarin Forms app there would be no difference in how you would use the SDK.
 
-1. Open `LaunchDarkly.HelloXamarin.sln` in Visual Studio.
+1. Open `LaunchDarkly.HelloDotNetClient.sln` in Visual Studio.
 
 2. Edit `Shared/DemoParameters.cs` and set the value of `MobileKey` to your LaunchDarkly SDK key. If there is an existing boolean feature flag in your LaunchDarkly project that you want to evaluate, set `FeatureFlagKey` to the flag key.
 
@@ -30,10 +30,10 @@ If you leave the app running and use your LaunchDarkly dashboard to turn the fla
 
 1. Edit `Shared/DemoParameters` as described above.
 
-2. If you are using Visual Studio, open `LaunchDarkly.HelloXamarin.sln` and run the `XamarinConsoleApp` project. Or, to run from the command line, type the following command:
+2. If you are using Visual Studio, open `LaunchDarkly.HelloDotNetClient.sln` and run the `DotNetConsoleApp` project. Or, to run from the command line, type the following command:
 
 ```
-    dotnet run --project XamarinConsoleApp
+    dotnet run --project DotNetConsoleApp
 ```
 
 You should see the message `"Feature flag '<flag key>' is <true/false> for this user"`.

--- a/Shared/DemoMessages.cs
+++ b/Shared/DemoMessages.cs
@@ -2,7 +2,7 @@
 namespace LaunchDarkly.Hello
 {
     // These strings are used by all three versions of the demo: XamarinAndroidApp,
-    // XamarinIOsApp, and XamarinConsoleApp.
+    // XamarinIOsApp, and DotNetConsoleApp.
 
     public static class DemoMessages
     {

--- a/Shared/DemoParameters.cs
+++ b/Shared/DemoParameters.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using LaunchDarkly.Client;
+using LaunchDarkly.Sdk;
 
 namespace LaunchDarkly.Hello
 {

--- a/Shared/DemoParameters.cs
+++ b/Shared/DemoParameters.cs
@@ -9,7 +9,7 @@ namespace LaunchDarkly.Hello
     public class DemoParameters
     {
         // Set MobileKey to your LaunchDarkly mobile key.
-        public const string MobileKey = "mob-f0c2ce9a-fdca-4190-b0da-8f6645a8330e";
+        public const string MobileKey = "";
 
         // Set FeatureFlagKey to the feature flag key you want to evaluate.
         public const string FeatureFlagKey = "my-boolean-flag";

--- a/XamarinAndroidApp/MainActivity.cs
+++ b/XamarinAndroidApp/MainActivity.cs
@@ -1,16 +1,17 @@
 ﻿using Android.App;
 using Android.Widget;
 using Android.OS;
-using LaunchDarkly.Xamarin;
+using LaunchDarkly.Sdk.Client;
+using LaunchDarkly.Sdk.Client.Interfaces;
 
 namespace LaunchDarkly.Hello
 {
-    // This is the Android version of the LaunchDarkly Xamarin SDK demo. The non-platform-specific
-    // classes DemoMessages and DemoParameters are defined in ../Shared.
+    // This is the Android version of the LaunchDarkly client-side .NET SDK demo. The
+    // non-platform-specific classes DemoMessages and DemoParameters are defined in ../Shared.
 
     // This file implements the application UI and demonstrates usage of the LaunchDarkly SDK.
 
-    [Activity(Label = "LaunchDarkly.Xamarin", MainLauncher = true, Icon = "@mipmap/icon")]
+    [Activity(Label = "LaunchDarkly.Hello", MainLauncher = true, Icon = "@mipmap/icon")]
     public class MainActivity : Activity
     {
         private ILdClient client;
@@ -38,7 +39,7 @@ namespace LaunchDarkly.Hello
                 if (client.Initialized)
                 {
                     UpdateFlagValue();
-                    client.FlagChanged += FeatureFlagChanged;
+                    client.FlagTracker.FlagValueChanged += FeatureFlagChanged;
                 }
                 else
                 {
@@ -58,7 +59,7 @@ namespace LaunchDarkly.Hello
             SetMessage(string.Format(DemoMessages.FlagValueIs, DemoParameters.FeatureFlagKey, flagValue));
         }
 
-        void FeatureFlagChanged(object sender, FlagChangedEventArgs args)
+        void FeatureFlagChanged(object sender, FlagValueChangeEvent args)
         {
             if (args.Key == DemoParameters.FeatureFlagKey)
             {

--- a/XamarinAndroidApp/XamarinAndroidApp.csproj
+++ b/XamarinAndroidApp/XamarinAndroidApp.csproj
@@ -46,7 +46,7 @@
     <Reference Include="System.Numerics" />
     <Reference Include="System.Numerics.Vectors" />
     <Reference Include="System.Xml" />
-    <PackageReference Include="LaunchDarkly.XamarinSdk" Version="1.*" />
+    <PackageReference Include="LaunchDarkly.ClientSdk" Version="2.0.0-rc.1" />
     <PackageReference Include="Xamarin.Android.Arch.Core.Runtime" Version="1.1.1.1" />
     <PackageReference Include="Xamarin.Android.Arch.Lifecycle.LiveData" Version="1.1.1.1" />
     <PackageReference Include="Xamarin.Android.Arch.Lifecycle.ViewModel" Version="1.1.1.1" />

--- a/XamarinIOSApp/Info.plist
+++ b/XamarinIOSApp/Info.plist
@@ -3,9 +3,9 @@
 <plist version="1.0">
 <dict>
 	<key>CFBundleName</key>
-	<string>LaunchDarkly.Xamarin.iOSApp</string>
+	<string>LaunchDarkly.Hello.iOSApp</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.launchdarkly.xamarin.iosapp</string>
+	<string>com.launchdarkly.hello.iosapp</string>
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
 	<key>CFBundleVersion</key>

--- a/XamarinIOSApp/Main.cs
+++ b/XamarinIOSApp/Main.cs
@@ -1,5 +1,4 @@
-﻿using Common.Logging;
-using UIKit;
+﻿using UIKit;
 
 namespace LaunchDarkly.Hello
 {
@@ -13,15 +12,7 @@ namespace LaunchDarkly.Hello
     {
         static void Main(string[] args)
         {
-            // Set up logging to log SDK messages to the console (console output can be viewed in
-            // Visual Studio).
-            var props = new global::Common.Logging.Configuration.NameValueCollection
-            {
-                { "level", "Debug" }
-            };
-            LogManager.Adapter = new global::Common.Logging.Simple.DebugLoggerFactoryAdapter(props);
-
-            UIApplication.Main(args, null, "AppDelegate");
+            UIApplication.Main(args, null, typeof(AppDelegate));
         }
     }
 }

--- a/XamarinIOSApp/MainCollectionViewController.cs
+++ b/XamarinIOSApp/MainCollectionViewController.cs
@@ -1,6 +1,7 @@
 using System;
 using UIKit;
-using LaunchDarkly.Xamarin;
+using LaunchDarkly.Sdk.Client;
+using LaunchDarkly.Sdk.Client.Interfaces;
 
 namespace LaunchDarkly.Hello
 {
@@ -34,7 +35,7 @@ namespace LaunchDarkly.Hello
                 if (client.Initialized)
                 {
                     UpdateFlagValue();
-                    client.FlagChanged += FeatureFlagChanged;
+                    client.FlagTracker.FlagValueChanged += FeatureFlagChanged;
                 }
                 else
                 {
@@ -59,7 +60,7 @@ namespace LaunchDarkly.Hello
             SetMessage(string.Format(DemoMessages.FlagValueIs, DemoParameters.FeatureFlagKey, flagValue));
         }
 
-        void FeatureFlagChanged(object sender, FlagChangedEventArgs args)
+        void FeatureFlagChanged(object sender, FlagValueChangeEvent args)
         {
             if (args.Key == DemoParameters.FeatureFlagKey)
             {

--- a/XamarinIOSApp/XamarinIOSApp.csproj
+++ b/XamarinIOSApp/XamarinIOSApp.csproj
@@ -87,7 +87,7 @@
     <Reference Include="System.Numerics.Vectors" />
     <Reference Include="System.Xml" />
     <Reference Include="Xamarin.iOS" />
-    <PackageReference Include="LaunchDarkly.XamarinSdk" Version="1.*" />
+    <PackageReference Include="LaunchDarkly.ClientSdk" Version="2.0.0-rc.1" />
   </ItemGroup>
   <ItemGroup>
     <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Contents.json" />


### PR DESCRIPTION
This is currently building against the 2.0.0-rc.1 version. Once the 2.0.0 GA release is out, I'll update the dependencies here to refer to `"2.*"` so it'll always get the latest 2.x release.