### PR TITLE
chore: update for 4.0 release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,7 @@ jobs:
       # Note that the dotnet CLI command can't be used with Xamarin projects; we must use msbuild
       - run:
           name: Build XamarinAndroidApp
-          command: msbuild /restore /p:Configuration=Debug /p:AndroidSdkDirectory=$ANDROID_SDK_ROOT XamarinAndroidApp/XamarinAndroidApp.csproj
+          command: msbuild /restore /p:Configuration=Debug /p:AndroidSdkDirectory=/usr/local/share/android-sdk XamarinAndroidApp/XamarinAndroidApp.csproj
 
       - run:
           name: Pre-build storyboard for iOS app

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,9 +65,9 @@ jobs:
           command: ./.circleci/macos-install-android-sdk.sh 28  # demo app currently uses Android 9.0 = API 28
 
       # Note that the dotnet CLI command can't be used with Xamarin projects; we must use msbuild
-      #- run:
-      #    name: Build XamarinAndroidApp
-      #    command: msbuild /restore /p:Configuration=Debug /p:AndroidSdkDirectory=$ANDROID_HOME XamarinAndroidApp/XamarinAndroidApp.csproj
+      - run:
+          name: Build XamarinAndroidApp
+          command: msbuild /restore /p:Configuration=Debug /p:AndroidSdkDirectory=$ANDROID_SDK_ROOT XamarinAndroidApp/XamarinAndroidApp.csproj
 
       - run:
           name: Pre-build storyboard for iOS app

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,6 +51,8 @@ jobs:
 
   build-macos:
     macos: # We're using a Mac host because that's the only way to build for Xamarin iOS
+      # If the xcode version (or possibly resource class) is updated, we'll need to install JDK 11 explicitly for use
+      # with Xamarin.
       xcode: "13.4.1"
     resource_class: macos.x86.medium.gen2
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,9 +65,9 @@ jobs:
           command: ./.circleci/macos-install-android-sdk.sh 28  # demo app currently uses Android 9.0 = API 28
 
       # Note that the dotnet CLI command can't be used with Xamarin projects; we must use msbuild
-      - run:
-          name: Build XamarinAndroidApp
-          command: msbuild /restore /p:Configuration=Debug /p:AndroidSdkDirectory=/Users/distiller/Library/Android/sdk XamarinAndroidApp/XamarinAndroidApp.csproj
+      #- run:
+      #    name: Build XamarinAndroidApp
+      #    command: msbuild /restore /p:Configuration=Debug /p:AndroidSdkDirectory=$ANDROID_HOME XamarinAndroidApp/XamarinAndroidApp.csproj
 
       - run:
           name: Pre-build storyboard for iOS app

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,16 +64,10 @@ jobs:
           name: Install Android SDK
           command: ./.circleci/macos-install-android-sdk.sh 28  # demo app currently uses Android 9.0 = API 28
 
-      - run:
-          name: Sanity check
-          command: |
-              ls /usr/local/share/android-sdk
-              echo "Android SDK Root is: $ANDROID_SDK_ROOT"
-
       # Note that the dotnet CLI command can't be used with Xamarin projects; we must use msbuild
       - run:
           name: Build XamarinAndroidApp
-          command: msbuild /restore /p:Configuration=Debug /p:AndroidSdkDirectory=/usr/local/share/android-sdk XamarinAndroidApp/XamarinAndroidApp.csproj
+          command: msbuild /restore /p:Configuration=Debug /p:AndroidSdkDirectory="$ANDROID_SDK_ROOT" XamarinAndroidApp/XamarinAndroidApp.csproj
 
       - run:
           name: Pre-build storyboard for iOS app

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,6 +52,7 @@ jobs:
   build-macos:
     macos: # We're using a Mac host because that's the only way to build for Xamarin iOS
       xcode: "15.0.0"
+    resource_class: macos.x86.medium.gen2
 
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ jobs:
 
   build-macos:
     macos: # We're using a Mac host because that's the only way to build for Xamarin iOS
-      xcode: "12.5.1"
+      xcode: "15.0.0"
 
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,6 @@ jobs:
       # If the xcode version (or possibly resource class) is updated, we'll need to install JDK 11 explicitly for use
       # with Xamarin.
       xcode: "13.4.1"
-    resource_class: macos.x86.medium.gen2
 
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,7 @@ jobs:
       # Note that the dotnet CLI command can't be used with Xamarin projects; we must use msbuild
       - run:
           name: Build XamarinAndroidApp
-          command: msbuild /restore /p:Configuration=Debug XamarinAndroidApp/XamarinAndroidApp.csproj
+          command: msbuild /restore /p:Configuration=Debug /p:AndroidSdkDirectory=/Users/distiller/Library/Android/sdk XamarinAndroidApp/XamarinAndroidApp.csproj
 
       - run:
           name: Pre-build storyboard for iOS app

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ jobs:
 
   build-macos:
     macos: # We're using a Mac host because that's the only way to build for Xamarin iOS
-      xcode: "15.0.0"
+      xcode: "13.4.1"
     resource_class: macos.x86.medium.gen2
 
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,7 @@ jobs:
       # Note that the dotnet CLI command can't be used with Xamarin projects; we must use msbuild
       - run:
           name: Build XamarinAndroidApp
-          command: msbuild /restore /p:Configuration=Debug /p:AndroidSdkDirectory="$ANDROID_SDK_ROOT" XamarinAndroidApp/XamarinAndroidApp.csproj
+          command: msbuild /restore /p:Configuration=Debug XamarinAndroidApp/XamarinAndroidApp.csproj
 
       - run:
           name: Pre-build storyboard for iOS app

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,6 +64,12 @@ jobs:
           name: Install Android SDK
           command: ./.circleci/macos-install-android-sdk.sh 28  # demo app currently uses Android 9.0 = API 28
 
+      - run:
+          name: Sanity check
+          command: |
+              ls /usr/local/share/android-sdk
+              echo "Android SDK Root is: $ANDROID_SDK_ROOT"
+
       # Note that the dotnet CLI command can't be used with Xamarin projects; we must use msbuild
       - run:
           name: Build XamarinAndroidApp

--- a/.circleci/macos-install-android-sdk.sh
+++ b/.circleci/macos-install-android-sdk.sh
@@ -59,7 +59,6 @@ unzip android-sdk.zip
 mv cmdline-tools $ANDROID_HOME/cmdline-tools/latest
 
 sdkmanager_args="platform-tools emulator"
-sdkmanager_args="$sdkmanager_args extras;intel;Hardware_Accelerated_Execution_Manager"
 sdkmanager_args="$sdkmanager_args build-tools;$ANDROID_BUILD_TOOLS_VERSION"
 for apiver in "$@"; do
   sdkmanager_args="$sdkmanager_args platforms;android-$apiver"

--- a/.circleci/macos-install-android-sdk.sh
+++ b/.circleci/macos-install-android-sdk.sh
@@ -19,7 +19,7 @@ if [ -z "$1" ]; then
   exit 1
 fi
 
-ANDROID_SDK_CMDLINE_TOOLS_DOWNLOAD_URL=https://dl.google.com/android/repository/commandlinetools-mac-6858069_latest.zip
+ANDROID_SDK_CMDLINE_TOOLS_DOWNLOAD_URL=https://dl.google.com/android/repository/commandlinetools-mac-10406996_latest.zip
 ANDROID_BUILD_TOOLS_VERSION=26.0.2
 
 if [ -z "$ANDROID_HOME" ]; then

--- a/.circleci/macos-install-android-sdk.sh
+++ b/.circleci/macos-install-android-sdk.sh
@@ -19,7 +19,7 @@ if [ -z "$1" ]; then
   exit 1
 fi
 
-ANDROID_SDK_CMDLINE_TOOLS_DOWNLOAD_URL=https://dl.google.com/android/repository/commandlinetools-mac-10406996_latest.zip
+ANDROID_SDK_CMDLINE_TOOLS_DOWNLOAD_URL=https://dl.google.com/android/repository/commandlinetools-mac-6858069_latest.zip
 ANDROID_BUILD_TOOLS_VERSION=26.0.2
 
 if [ -z "$ANDROID_HOME" ]; then

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ Thumbs.db
 
 # dotCover
 *.dotCover
+
+# jetBrains
+.idea

--- a/DotNetConsoleApp/DotNetConsoleApp.csproj
+++ b/DotNetConsoleApp/DotNetConsoleApp.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LaunchDarkly.ClientSdk" Version="3.*" />
+    <PackageReference Include="LaunchDarkly.ClientSdk" Version="4.*" />
   </ItemGroup>
   <Import Project="..\Shared\Shared.projitems" Label="Shared" Condition="Exists('..\Shared\Shared.projitems')" />
 </Project>

--- a/DotNetConsoleApp/Program.cs
+++ b/DotNetConsoleApp/Program.cs
@@ -1,9 +1,9 @@
 ﻿using System;
-using LaunchDarkly.Logging;
+using LaunchDarkly.Hello;
 using LaunchDarkly.Sdk.Client;
-using ConfigurationBuilder = LaunchDarkly.EventSource.ConfigurationBuilder;
+using ConfigurationBuilder = LaunchDarkly.Sdk.Client.ConfigurationBuilder;
 
-namespace LaunchDarkly.Hello
+namespace DotNetConsoleApp
 {
     // This is the .NET Core console version of the LaunchDarkly client-side .NET SDK demo. The
     // non-platform-specific classes DemoMessages and DemoParameters are defined in ../Shared.
@@ -18,10 +18,10 @@ namespace LaunchDarkly.Hello
                 Environment.Exit(1);
             }
 
-            LdClient client = LdClient.Init(
-                Configuration.Default(DemoParameters.MobileKey, Sdk.Client.ConfigurationBuilder.AutoEnvAttributes.Enabled),
+            var client = LdClient.Init(
+                Configuration.Default(DemoParameters.MobileKey, ConfigurationBuilder.AutoEnvAttributes.Enabled),
                 DemoParameters.MakeDemoContext(),
-                DemoParameters.SDKTimeout
+                DemoParameters.SdkTimeout
             );
 
             if (client.Initialized)

--- a/DotNetConsoleApp/Program.cs
+++ b/DotNetConsoleApp/Program.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using LaunchDarkly.Logging;
 using LaunchDarkly.Sdk.Client;
+using ConfigurationBuilder = LaunchDarkly.EventSource.ConfigurationBuilder;
 
 namespace LaunchDarkly.Hello
 {
@@ -18,7 +19,7 @@ namespace LaunchDarkly.Hello
             }
 
             LdClient client = LdClient.Init(
-                DemoParameters.MobileKey,
+                Configuration.Default(DemoParameters.MobileKey, Sdk.Client.ConfigurationBuilder.AutoEnvAttributes.Enabled),
                 DemoParameters.MakeDemoContext(),
                 DemoParameters.SDKTimeout
             );

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright 2019 Catamorphic, Co.
+Copyright 2023 Catamorphic, Co.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Shared/DemoParameters.cs
+++ b/Shared/DemoParameters.cs
@@ -6,7 +6,7 @@ namespace LaunchDarkly.Hello
     // These values are used by all three versions of the demo: XamarinAndroidApp,
     // XamarinIOsApp, and XamarinConsoleApp.
 
-    public class DemoParameters
+    public static class DemoParameters
     {
         // Set MobileKey to your LaunchDarkly mobile key.
         public const string MobileKey = "";
@@ -22,6 +22,6 @@ namespace LaunchDarkly.Hello
                 .Build();
 
         // How long the application will wait for the SDK to connect to LaunchDarkly
-        public static TimeSpan SDKTimeout = TimeSpan.FromSeconds(10);
+        public static TimeSpan SdkTimeout = TimeSpan.FromSeconds(10);
     }
 }

--- a/XamarinAndroidApp/MainActivity.cs
+++ b/XamarinAndroidApp/MainActivity.cs
@@ -1,8 +1,10 @@
 ﻿using Android.App;
+using Android.Graphics;
 using Android.Widget;
 using Android.OS;
 using LaunchDarkly.Sdk.Client;
 using LaunchDarkly.Sdk.Client.Interfaces;
+using ConfigurationBuilder = LaunchDarkly.Sdk.Client.ConfigurationBuilder;
 
 namespace LaunchDarkly.Hello
 {
@@ -32,9 +34,9 @@ namespace LaunchDarkly.Hello
             {
                 client = LdClient.Init(
                     // These values are set in the Shared project
-                    DemoParameters.MobileKey,
+                    Configuration.Default(DemoParameters.MobileKey, ConfigurationBuilder.AutoEnvAttributes.Enabled),
                     DemoParameters.MakeDemoContext(),
-                    DemoParameters.SDKTimeout
+                    DemoParameters.SdkTimeout
                 );
                 if (client.Initialized)
                 {

--- a/XamarinAndroidApp/MainActivity.cs
+++ b/XamarinAndroidApp/MainActivity.cs
@@ -1,5 +1,4 @@
 ﻿using Android.App;
-using Android.Graphics;
 using Android.Widget;
 using Android.OS;
 using LaunchDarkly.Sdk.Client;

--- a/XamarinAndroidApp/Properties/AndroidManifest.xml
+++ b/XamarinAndroidApp/Properties/AndroidManifest.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="com.launchdarkly.XamarinAndroidApp">
-	<uses-sdk android:minSdkVersion="28" android:targetSdkVersion="28" />
+	<uses-sdk android:minSdkVersion="15" android:targetSdkVersion="28" />
 	<application android:label="Hello Xamarin Android"></application>
 </manifest>

--- a/XamarinAndroidApp/Properties/AndroidManifest.xml
+++ b/XamarinAndroidApp/Properties/AndroidManifest.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="com.launchdarkly.XamarinAndroidApp">
-	<uses-sdk android:minSdkVersion="15" android:targetSdkVersion="28" />
+	<uses-sdk android:minSdkVersion="28" android:targetSdkVersion="28" />
 	<application android:label="Hello Xamarin Android"></application>
 </manifest>

--- a/XamarinAndroidApp/XamarinAndroidApp.csproj
+++ b/XamarinAndroidApp/XamarinAndroidApp.csproj
@@ -46,7 +46,7 @@
     <Reference Include="System.Numerics" />
     <Reference Include="System.Numerics.Vectors" />
     <Reference Include="System.Xml" />
-    <PackageReference Include="LaunchDarkly.ClientSdk" Version="3.*" />
+    <PackageReference Include="LaunchDarkly.ClientSdk" Version="4.*" />
     <PackageReference Include="Xamarin.Android.Arch.Core.Runtime" Version="1.1.1.1" />
     <PackageReference Include="Xamarin.Android.Arch.Lifecycle.LiveData" Version="1.1.1.1" />
     <PackageReference Include="Xamarin.Android.Arch.Lifecycle.ViewModel" Version="1.1.1.1" />

--- a/XamarinIOSApp/MainCollectionViewController.cs
+++ b/XamarinIOSApp/MainCollectionViewController.cs
@@ -2,6 +2,7 @@ using System;
 using UIKit;
 using LaunchDarkly.Sdk.Client;
 using LaunchDarkly.Sdk.Client.Interfaces;
+using ConfigurationBuilder = LaunchDarkly.Sdk.Client.ConfigurationBuilder;
 
 namespace LaunchDarkly.Hello
 {
@@ -28,9 +29,9 @@ namespace LaunchDarkly.Hello
             else
             {
                 client = LdClient.Init(
-                    DemoParameters.MobileKey,
+                    Configuration.Default(DemoParameters.MobileKey, ConfigurationBuilder.AutoEnvAttributes.Enabled),
                     DemoParameters.MakeDemoContext(),
-                    DemoParameters.SDKTimeout
+                    DemoParameters.SdkTimeout
                 );
                 if (client.Initialized)
                 {

--- a/XamarinIOSApp/XamarinIOSApp.csproj
+++ b/XamarinIOSApp/XamarinIOSApp.csproj
@@ -87,7 +87,7 @@
     <Reference Include="System.Numerics.Vectors" />
     <Reference Include="System.Xml" />
     <Reference Include="Xamarin.iOS" />
-    <PackageReference Include="LaunchDarkly.ClientSdk" Version="3.*" />
+    <PackageReference Include="LaunchDarkly.ClientSdk" Version="4.*" />
   </ItemGroup>
   <ItemGroup>
     <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Contents.json" />


### PR DESCRIPTION
Updates the hello apps for usage with .NET Client-side SDK 4.0. The main change is to add the auto-env-attribute opt-in value to the config constructors.

I've also fixed the build by bumping the xcode version. Finally, I pinned the macOS executor since this one won't go EOL until January 2024.

Side note: this should be squash merged 😓 